### PR TITLE
fix dependency 更新 numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ python setup.py develop
 ```
 
 ## 预训练权重下载
-下载预训练[权重](https://github.com/7eu7d7/genshin_auto_fish/releases/tag/weights) (.pth文件),[yolox_tiny.pth](https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_tiny.pth)
+
+- [`best_tiny3.pth`](https://github.com/7eu7d7/genshin_auto_fish/releases/download/weights/best_tiny3.pth)
+- [`fish_genshin_net.pth`](https://github.com/7eu7d7/genshin_auto_fish/releases/download/weights/fish_genshin_net.pth)
+- [`fish_sim_net.pth`](https://github.com/7eu7d7/genshin_auto_fish/releases/download/weights/fish_sim_net.pth)
+- [`yolox_tiny.pth`](https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_tiny.pth)
+
 下载后将权重文件放在 <font color=#66CCFF>**工程目录/weights**</font> 下
 
 # 运行钓鱼AI

--- a/requirements.py
+++ b/requirements.py
@@ -48,7 +48,7 @@ def main():
     keyboard
     Pillow
     pymouse
-    numpy==1.19.5
+    numpy>=1.21.1
     torch==1.8.2+{"cpu" if args.cuda is None else "cu" + args.cuda} -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
     torchvision==0.9.2+{"cpu" if args.cuda is None else "cu" + args.cuda} --no-deps -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
     thop --no-deps


### PR DESCRIPTION
```text
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
matplotlib 3.7.2 requires numpy>=1.20, but you have numpy 1.19.5 which is incompatible.
scikit-image 0.21.0 requires numpy>=1.21.1, but you have numpy 1.19.5 which is incompatible.
```